### PR TITLE
static object constructor

### DIFF
--- a/src/MainFace.cpp
+++ b/src/MainFace.cpp
@@ -119,7 +119,7 @@ void MainFace::allChange()
 PluginRegistrarBase::PluginRegistrarBase(std::string const& _name, PluginFactory const& _f):
 	m_name(_name)
 {
-	cdebug << "Noting linked plugin" << _name;
+	//cdebug << "Noting linked plugin" << _name;
 	MainFace::notePlugin(_name, _f);
 }
 


### PR DESCRIPTION
Must not call one static object (logger) from the constructor of another static object (PluginRegistrarBase), because initialization order is undefined. In my environment is causes crash.
