### PR TITLE
Include default cmake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ include(EthExecutableHelper)
 # Include utils
 include(EthUtils)
 
+include(EthOptions)
+configure_project()
+print_config()
+
 # required for qt5_wrap_ui below, TODO: remove this
 find_package(Qt5Widgets)
 


### PR DESCRIPTION
Just like with [this](https://github.com/ethereum/webthree/pull/34) PR
alethzero can't be built with the split repositories way in Windows
unless those defaults are in.
