### PR TITLE
fix gpu mining in Alethone

### DIFF
--- a/alethone/AlethOne.cpp
+++ b/alethone/AlethOne.cpp
@@ -179,7 +179,7 @@ void AlethOne::on_mining_toggled(bool _on)
 	if (_on)
 	{
 #ifdef NDEBUG
-		char const* sealer = "gpu";
+		char const* sealer = "opencl";
 #else
 		char const* sealer = "cpu";
 #endif


### PR DESCRIPTION
One should consider an extra compile flag for CPU mining instead if DEBUG and RELEASE mode
