### PR TITLE
Fix a "Solidity::solidity" dependency edge in the CMake file for alethzero

### DIFF
--- a/alethzero/CMakeLists.txt
+++ b/alethzero/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(${EXECUTABLE} aleth)
 target_include_directories(${EXECUTABLE} PUBLIC ..)
 eth_use(${EXECUTABLE} REQUIRED Qt::Core Qt::Widgets Qt::WebEngineWidgets Eth::ethereum Web3::web3jsonrpc Eth::natspec Eth::ethashseal)
 if (SOLIDITY)
-	eth_use(${EXECUTABLE} OPTIONAL Solidity)
+	eth_use(${EXECUTABLE} OPTIONAL Solidity::solidity)
 endif()
 
 # required because AUTOUIC can't handle multiple ui includes in one cpp file


### PR DESCRIPTION
Fix a "Solidity::solidity" dependency edge in the CMake file for alethzero.

This change resolves an inconsistency which was discovered in the automated dependency graph generation.
softest was being declared as dependent on the Solidity module, not on just libsolidity, as it should be.
