### PR TITLE
Remove client name from version string.

### DIFF
--- a/alethzero/AlethZero.cpp
+++ b/alethzero/AlethZero.cpp
@@ -243,7 +243,7 @@ void AlethZero::setNetPrefs(NetworkSettings const& _settings)
 	p.discovery = p.discovery && !aleth()->isTampered();
 	p.pin = p.pin || aleth()->isTampered();
 	aleth()->web3()->setNetworkPreferences(p, _settings.dropPeers);
-	aleth()->web3()->setClientVersion(WebThreeDirect::composeClientVersion("AlethZero", _settings.clientName.toStdString()));
+	aleth()->web3()->setClientVersion(WebThreeDirect::composeClientVersion("AlethZero"));
 	QSettings s("ethereum", "alethzero");
 	_settings.write(s);
 }

--- a/libaleth/Aleth.cpp
+++ b/libaleth/Aleth.cpp
@@ -126,7 +126,7 @@ bool Aleth::open(OnInit _connect)
 			return false;
 		}
 
-		web3()->setClientVersion(WebThreeDirect::composeClientVersion(m_clientVersion, m_nodeName));
+		web3()->setClientVersion(WebThreeDirect::composeClientVersion(m_clientVersion));
 		setAuthor(keyManager().accounts().front());
 		ethereum()->setDefault(LatestBlock);
 


### PR DESCRIPTION
Remove the client name from the version string reported via rpc and use `/` to separate components.

Fixes https://github.com/ethereum/webthree-umbrella/issues/128

DEPENDS: {
"webthree": "noclientname"
}
