### PR TITLE
Normalize version string in AlethZero, and switch attribution

### DIFF
--- a/alethzero/AlethZero.cpp
+++ b/alethzero/AlethZero.cpp
@@ -197,7 +197,13 @@ void AlethZero::warn(QString _s)
 
 void AlethZero::on_about_triggered()
 {
-	QMessageBox::about(this, "About " + windowTitle(), QString("AlethZero/v") + dev::Version + "/" DEV_QUOTED(ETH_BUILD_TYPE) "/" DEV_QUOTED(ETH_BUILD_PLATFORM) "\n" DEV_QUOTED(ETH_COMMIT_HASH) + (ETH_CLEAN_REPO ? "\nCLEAN" : "\n+ LOCAL CHANGES") + "\n\nBy the Berlin ÐΞV team, 2014, 2015, 2016.\nSee the README for contributors and credits.");
+	QString versionString(WebThreeDirect::composeClientVersion("AlethZero"));
+
+	versionString += "\n";
+	versionString += "\nBy cpp-ethereum contributors, 2014-2016.";
+	versionString += "\nSee the README for contributors and credits.";
+
+	QMessageBox::about(this, "About " + windowTitle(), versionString);
 }
 
 void AlethZero::writeSettings()
@@ -243,7 +249,7 @@ void AlethZero::setNetPrefs(NetworkSettings const& _settings)
 	p.discovery = p.discovery && !aleth()->isTampered();
 	p.pin = p.pin || aleth()->isTampered();
 	aleth()->web3()->setNetworkPreferences(p, _settings.dropPeers);
-	aleth()->web3()->setClientVersion(WebThreeDirect::composeClientVersion("AlethZero", _settings.clientName.toStdString()));
+	aleth()->web3()->setClientVersion(WebThreeDirect::composeClientVersion("AlethZero"));
 	QSettings s("ethereum", "alethzero");
 	_settings.write(s);
 }


### PR DESCRIPTION
Use WebThreeDirect::composeClientVersion(), rather than composing the version string manually here.

Also switched the attribution to "cpp-ethereum contributors".
