### PR TITLE
Fixed AlethZero build break in new code.

### DIFF
--- a/alethzero/AlethZero.cpp
+++ b/alethzero/AlethZero.cpp
@@ -197,7 +197,7 @@ void AlethZero::warn(QString _s)
 
 void AlethZero::on_about_triggered()
 {
-	QString versionString(WebThreeDirect::composeClientVersion("AlethZero"));
+	QString versionString = QString::fromStdString(WebThreeDirect::composeClientVersion("AlethZero"));
 
 	versionString += "\n";
 	versionString += "\nBy cpp-ethereum contributors, 2014-2016.";


### PR DESCRIPTION
Not sure why my CLion build didn't show this build break.
Just saw this from a clean CMake/make run.
