### PR TITLE
Fix broken agent version strings for AlethZero and AlethOne.

### DIFF
--- a/libaleth/Aleth.cpp
+++ b/libaleth/Aleth.cpp
@@ -119,7 +119,7 @@ bool Aleth::open(OnInit _connect)
 
 		try
 		{
-			m_webThree.reset(new WebThreeDirect(m_clientVersion + "/v" + niceVersion(dev::Version) + "/" DEV_QUOTED(ETH_BUILD_TYPE) "/" DEV_QUOTED(ETH_BUILD_PLATFORM), m_dbPath, m_baseParams, WithExisting::Trust, {"eth", "bzz", "shh"}, p2p::NetworkPreferences(), network));
+			m_webThree.reset(new WebThreeDirect(WebThreeDirect::composeClientVersion(m_clientVersion), m_dbPath, m_baseParams, WithExisting::Trust, {"eth", "bzz", "shh"}, p2p::NetworkPreferences(), network));
 		}
 		catch (DatabaseAlreadyOpen&)
 		{


### PR DESCRIPTION
It appears likely that all Aleth\* agent strings have been broken forever.
Fixes https://github.com/ethereum/webthree-umbrella/issues/304.
