### PR TITLE
AlethZero fixes for Qt 5.6 support on OS X

### DIFF
--- a/alethzero/plugins/browser/Browser.cpp
+++ b/alethzero/plugins/browser/Browser.cpp
@@ -25,9 +25,9 @@
 #pragma GCC diagnostic ignored "-Wpedantic"
 #include <QFileDialog>
 #include <QtWebEngine/QtWebEngine>
-#include <QtWebEngineWidgets/QWebEngineView>
-#include <QtWebEngineWidgets/QWebEngineCallback>
-#include <QtWebEngineWidgets/QWebEngineSettings>
+#include <QtWebEngineWidgets/qwebengineview.h>
+#include <QtWebEngineWidgets/qwebenginepage.h>
+#include <QtWebEngineWidgets/qwebenginesettings.h>
 #include <libaleth/AlethWhisper.h>
 #include <libaleth/AlethFace.h>
 #include <libaleth/DappHost.h>


### PR DESCRIPTION
These are required because Homebrew has updated Qt to 5.6 underneath us.
It looks like some backwards-compatibility headers for QtWebEngineWidgets were removed, so the build was broken against Qt 5.6, though these changes will work with older Qt versions too.
