### PR TITLE
Update version number to v1.2.6.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(EthPolicy)
 eth_policy()
 
 # project name and version should be set after cmake_policy CMP0048
-project(alethzero VERSION "1.2.5")
+project(alethzero VERSION "1.2.6")
 
 # Let's find our dependencies
 include(EthDependencies)


### PR DESCRIPTION
There are no changes since v.1.2.5, but we're re-publishing the whole umbrella, and everything is still lock stepped.
